### PR TITLE
Add instructions for connecting to Redshift

### DIFF
--- a/ssh-ec2.sh
+++ b/ssh-ec2.sh
@@ -83,7 +83,7 @@ if [[ "${DB_HOST}" ]]; then
   echo -e "3. Open another tab in your terminal to create a tunnel to RDS and run the following command"
   echo -e "  ${GREEN}aws ssm start-session --target $INSTANCE_ID --document-name AWS-StartPortForwardingSession --parameters '{\"portNumber\":[\"$DB_PORT\"], \"localPortNumber\":[\"$DB_PORT\"]}' --profile $AWS_ACCOUNT${RESET_COLOR} --region $REGION \\n"
   echo -e "4. Now you can connect locally without the need of using the bastion host. As additional step, use localhost as host for the database. As an example for postgres:"
-  echo -e " ${GREEN}psql -h localhost -p 5432 -U <user> -d <database>${RESET_COLOR} \\n"
+  echo -e " ${GREEN}psql -h localhost -p $DB_PORT -U <user> -d <database>${RESET_COLOR} \\n"
 fi
 
 aws ssm start-session --target $INSTANCE_ID --profile $AWS_ACCOUNT --region $REGION


### PR DESCRIPTION
The helper script is updated to include display instruction for creating a tunnnel to the Redshift database.

EC2 instances running BI applications are used as jump host to make the connection to Redshift database.

